### PR TITLE
Add Terraform configuration for basic GKE cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # simple-gke
+
+## GKE Cluster Configuration
+
+This repository contains Terraform configuration for a basic GKE cluster with:
+- e2-medium machine type (2 vCPU)
+- us-west1 region
+- 3 nodes with 16GB boot disk each
+- Default network route for internet gateway
+
+### Prerequisites
+- Google Cloud Project with required APIs enabled
+- Terraform installed
+- Google Cloud credentials configured
+
+### Usage
+```bash
+cd terraform
+terraform init
+terraform plan
+terraform apply
+```

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,4 @@
+.terraform
+*.tfstate
+*.tfstate.*
+.terraform.lock.hcl

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,39 @@
+provider "google" {
+  project = "<YOUR_PROJECT_ID>"
+  region  = "us-west1"
+}
+
+resource "google_container_cluster" "gke_cluster" {
+  name     = "basic-gke-cluster"
+  location = "us-west1"
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  network    = "default"
+  subnetwork = "default"
+}
+
+resource "google_container_node_pool" "default_pool" {
+  name       = "default-pool"
+  cluster    = google_container_cluster.gke_cluster.name
+  location   = google_container_cluster.gke_cluster.location
+  node_count = 3
+
+  node_config {
+    machine_type = "e2-medium"
+    disk_size_gb = 16
+    preemptible  = false
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+  }
+}
+
+resource "google_compute_route" "default_internet_gateway" {
+  name             = "default-internet-gateway"
+  network          = "default"
+  dest_range       = "0.0.0.0/0"
+  next_hop_gateway = "default-internet-gateway"
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds Terraform configuration for deploying a basic GKE cluster in Google Cloud. Changes include:

- Created `terraform/main.tf` with GKE cluster and node pool configuration
- Added `terraform/versions.tf` specifying required provider versions
- Created `terraform/.gitignore` for Terraform-specific files
- Updated README.md with deployment instructions and prerequisites

The configuration creates:
- A GKE cluster in us-west1 region
- Node pool with 3 e2-medium instances
- Default network route for internet access
- 16GB boot disks for each node

All resources use the default VPC network and subnetwork for simplicity.