### PR TITLE
Add Express.js server application

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -3,6 +3,7 @@ FROM node:18-alpine
 
 # Create app directory
 WORKDIR /usr/src/app
+COPY app.js .
 
 # Install app dependencies
 COPY package*.json ./

--- a/app/app.js
+++ b/app/app.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+    res.send('Hello World!');
+});
+
+app.listen(PORT, () => {
+    console.log(`Server is running on port ${PORT}`);
+});

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -16,5 +16,6 @@ spec:
         - name: hello-world
           image: us-docker.pkg.dev/gen-lang-client-0683956833/hello-world/hello-world:latest
           imagePullPolicy: Always
+          command: ["node", "app.js"]
           ports:
             - containerPort: 3000


### PR DESCRIPTION
This PR adds a basic Express.js server implementation with the following changes:

- Created new `app.js` with a basic Express server and Hello World endpoint
- Updated Dockerfile to copy `app.js` into the container
- Modified k8s deployment to run the Node.js application

The server will run on port 3000 by default or use the PORT environment variable if specified.